### PR TITLE
Add macOS watcher and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import gleam/io
 pub fn main() {
   let _ = radiate.new()
     |> radiate.add_dir("src")
-    |> radiate.on_reload(fn (path) {
+    |> radiate.on_reload(fn (_state, path) {
       io.println("Change in " <> path <> ", reloading!")
     })
     |> radiate.start()

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,15 +6,14 @@ version = "0.3.0"
 #
 description = "Hot reloading while in development for Gleam"
 licences = ["Apache-2.0"]
-repository = { type = "github", user = "pta2002", repo = "gleam-radiate" }
-gleam = ">= 0.32.0"
+repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.31"
-filespy = "~> 0.2"
-shellout = "~> 1.4"
-gleam_otp = "~> 0.7"
+filespy = "~> 0.3"
+gleam_otp = "~> 0.10"
+gleam_stdlib = "~> 0.34 or ~> 1.0"
+shellout = "~> 1.5"
 
 [dev-dependencies]
-gleeunit = "~> 0.10"
+gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,18 +2,18 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filespy", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_stdlib", "fs", "gleam_erlang"], otp_app = "filespy", source = "hex", outer_checksum = "E30CD4E81773C3814B6E1967266732118D1C07C958B78CD57D63A5B1FA4A4A87" },
+  { name = "filespy", version = "0.3.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "75F5910B31A528681D25316AAAE6C91CD3E977BD2492946564B7242FF941FB7A" },
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
-  { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
-  { name = "gleam_otp", version = "0.8.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "18EF8242A5E54BA92F717C7222F03B3228AEE00D1F286D4C56C3E8C18AA2588E" },
-  { name = "gleam_stdlib", version = "0.32.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "ABF00CDCCB66FABBCE351A50060964C4ACE798F95A0D78622C8A7DC838792577" },
-  { name = "gleeunit", version = "0.11.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "1397E5C4AC4108769EE979939AC39BF7870659C5AFB714630DEEEE16B8272AD5" },
-  { name = "shellout", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "995564B69D40146B7A424CA21D32A68D668A882F88BDAD0EFA2C18C7EC412564" },
+  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
+  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
+  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
 ]
 
 [requirements]
-filespy = { version = "~> 0.2" }
-gleam_otp = { version = "~> 0.7" }
-gleam_stdlib = { version = "~> 0.31" }
-gleeunit = { version = "~> 0.10" }
-shellout = { version = "~> 1.4" }
+filespy = { version = "~> 0.3" }
+gleam_otp = { version = "~> 0.10" }
+gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleeunit = { version = "~> 1.0" }
+shellout = { version = "~> 1.5" }

--- a/src/radiate.gleam
+++ b/src/radiate.gleam
@@ -107,7 +107,7 @@ pub fn start_state(builder: Builder(state, HasDirectories, HasInitializer)) {
       state,
       fn(state, event) {
         case event {
-          filespy.Closed -> {
+          filespy.Closed | filespy.Modified -> {
             // Check if path ends in '.gleam'
             case string.ends_with(path, ".gleam") {
               True -> {


### PR DESCRIPTION
Everything is mentioned in #1, but in case, the actual cases for files watcher was incorrect for macOS, because the event sent is `Modified` and not `Closed`. This fixes it.

In the same time, it updates everything to be used easily on Gleam 1.0.

### Issue
- Closes #1 