### PR TITLE
Update filespy and add a default callback, as well as only one callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Now, go ahead and change the text `get_message` returns to `"Hello, world!"`, an
 
 As soon as you save, the message printed is changed to "Hello, world!", without needing to restart the program!
 
+### Warning for macOS users
+
+Right now, the `add_dir` function only supports `"."` or an absolute path! Be careful to resolve the path to get it work if you want to watch `"src"` for example.
+
 ## Adding a callback
 
 You can add callbacks to be run every time code is reloaded through `on_reload`:

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-filespy = "~> 0.3"
+filespy = ">= 0.4.0 and < 1.0.0"
 gleam_otp = "~> 0.10"
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 shellout = "~> 1.5"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,7 +2,7 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filespy", version = "0.3.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "75F5910B31A528681D25316AAAE6C91CD3E977BD2492946564B7242FF941FB7A" },
+  { name = "filespy", version = "0.4.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "950469A2FA50265EB84530637D3E9597C2CA676A2EEABC98C69A83C77316709C" },
   { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
@@ -12,7 +12,7 @@ packages = [
 ]
 
 [requirements]
-filespy = { version = "~> 0.3" }
+filespy = { version = ">= 0.4.0 and < 1.0.0"}
 gleam_otp = { version = "~> 0.10" }
 gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/radiate.gleam
+++ b/src/radiate.gleam
@@ -42,6 +42,9 @@ pub fn new() -> Builder(Nil, NoDirectories, NoInitializer, NoCallback) {
   |> Builder(dirs: [], callback: _, initializer: None)
 }
 
+/// Add a directory to watch. The path can be relative or absolute.
+/// macOS users: always use `"."` or an absolute path, otherwise it won't work
+/// properly!
 pub fn add_dir(
   builder: Builder(state, has_dirs, has_initializer, has_callback),
   dir: String,


### PR DESCRIPTION
Hi!

This PR updates filespy to v0.4.0 to stay in sync, and it adds a default callback in the builder, to indicate a file has been reloaded.
It also adds a new phantom type to ensure callback can only be defined once, as suggested in the the todo.

I'm also tracking what could be a bug on macOS with `fs` (5HT/fs#72), and I'll think I'll do a second PR once that problem is solved (whether with an updated README or with an updated `fs`).
Meanwhile, maybe it's still worth to release an intermediate version of `radiate` to let everyone enjoy the working version for macOS!