### PR TITLE
Add before_reload callback

### DIFF
--- a/src/radiate.gleam
+++ b/src/radiate.gleam
@@ -24,47 +24,105 @@ pub type NoCallback
 /// Phantom type to indicate builder has callback
 pub type HasCallback
 
+/// Phantom type to indicate builder has before callback
+pub type HasBeforeCallback
+
+/// Phantom type to indicate builder has no before callback
+pub type NoBeforeCallback
+
 /// Opaque builder type for reloader. Create with `new`.
-pub opaque type Builder(state, has_dirs, has_initializer, has_callback) {
+pub opaque type Builder(
+  state,
+  has_dirs,
+  has_initializer,
+  has_callback,
+  has_before_callback,
+) {
   Builder(
     dirs: List(String),
     callback: fn(state, String) -> state,
     initializer: Option(fn() -> state),
+    before_callback: Option(fn(state, String) -> state),
   )
 }
 
 /// Construct a new builder
-pub fn new() -> Builder(Nil, NoDirectories, NoInitializer, NoCallback) {
+pub fn new() -> Builder(
+  Nil,
+  NoDirectories,
+  NoInitializer,
+  NoCallback,
+  NoBeforeCallback,
+) {
   fn(state, path) {
     io.println("Change in " <> path <> ", reloading.")
     state
   }
-  |> Builder(dirs: [], callback: _, initializer: None)
+  |> Builder(dirs: [], callback: _, initializer: None, before_callback: None)
 }
 
 /// Add a directory to watch. The path can be relative or absolute.
 /// macOS users: always use `"."` or an absolute path, otherwise it won't work
 /// properly!
 pub fn add_dir(
-  builder: Builder(state, has_dirs, has_initializer, has_callback),
+  builder: Builder(
+    state,
+    has_dirs,
+    has_initializer,
+    has_callback,
+    has_before_callback,
+  ),
   dir: String,
-) -> Builder(state, HasDirectories, has_initializer, has_callback) {
+) -> Builder(
+  state,
+  HasDirectories,
+  has_initializer,
+  has_callback,
+  has_before_callback,
+) {
   Builder(
     dirs: [dir, ..builder.dirs],
     callback: builder.callback,
     initializer: builder.initializer,
+    before_callback: builder.before_callback,
   )
 }
 
 /// Add a callback to be run after reload
 pub fn on_reload(
-  builder: Builder(state, has_dirs, has_initializer, NoCallback),
+  builder: Builder(
+    state,
+    has_dirs,
+    has_initializer,
+    NoCallback,
+    has_before_callback,
+  ),
   callback: fn(state, String) -> state,
-) -> Builder(state, has_dirs, has_initializer, HasCallback) {
+) -> Builder(state, has_dirs, has_initializer, HasCallback, has_before_callback) {
   Builder(
     dirs: builder.dirs,
     callback: callback,
     initializer: builder.initializer,
+    before_callback: builder.before_callback,
+  )
+}
+
+/// Add a callback to handle a process before reloading modules
+pub fn before_reload(
+  builder: Builder(
+    state,
+    has_dirs,
+    has_initializer,
+    has_callback,
+    NoBeforeCallback,
+  ),
+  before_callback: fn(state, String) -> state,
+) -> Builder(state, has_dirs, has_initializer, has_callback, HasBeforeCallback) {
+  Builder(
+    dirs: builder.dirs,
+    callback: builder.callback,
+    initializer: builder.initializer,
+    before_callback: Some(before_callback),
   )
 }
 
@@ -73,13 +131,20 @@ pub fn on_reload(
 /// This will be run in the file watcher process, so it can be useful to, for
 /// example, add state to an actor
 pub fn set_initializer(
-  builder: Builder(state, has_dirs, NoInitializer, has_callback),
+  builder: Builder(
+    state,
+    has_dirs,
+    NoInitializer,
+    has_callback,
+    has_before_callback,
+  ),
   initializer: fn() -> state,
-) -> Builder(state, has_dirs, HasInitializer, has_callback) {
+) -> Builder(state, has_dirs, HasInitializer, has_callback, has_before_callback) {
   Builder(
     dirs: builder.dirs,
     callback: builder.callback,
     initializer: Some(initializer),
+    before_callback: builder.before_callback,
   )
 }
 
@@ -97,15 +162,60 @@ fn purge(module: Module) -> Bool
 fn atomic_load(modules: List(Module)) -> Result(Nil, List(#(Module, What)))
 
 /// Start reloader, if no state has been set
-pub fn start(builder: Builder(Nil, HasDirectories, NoInitializer, has_callback)) {
+pub fn start(
+  builder: Builder(
+    Nil,
+    HasDirectories,
+    NoInitializer,
+    has_callback,
+    has_before_callback,
+  ),
+) {
   builder
   |> set_initializer(fn() { Nil })
   |> start_state()
 }
 
+/// Execute the file reload
+fn execute_reload(
+  builder: Builder(
+    state,
+    HasDirectories,
+    HasInitializer,
+    has_callback,
+    has_before_callback,
+  ),
+  state,
+  path,
+) -> state {
+  let build_result = shellout.command(["build"], run: "gleam", in: ".", opt: [])
+
+  case build_result {
+    Ok(_output) -> {
+      let mods = modified_modules()
+      list.each(mods, purge)
+      let _ = atomic_load(mods)
+      builder.callback(state, path)
+    }
+
+    Error(#(_status, message)) -> {
+      message
+      |> io.print_error
+
+      state
+    }
+  }
+}
+
 /// Start reloader, ensuring that a state has been set
 pub fn start_state(
-  builder: Builder(state, HasDirectories, HasInitializer, has_callback),
+  builder: Builder(
+    state,
+    HasDirectories,
+    HasInitializer,
+    has_callback,
+    has_before_callback,
+  ),
 ) {
   filespy.new()
   |> filespy.set_initializer(fn() {
@@ -124,26 +234,19 @@ pub fn start_state(
               // Check if path ends in '.gleam'
               case string.ends_with(path, ".gleam") {
                 True -> {
-                  // Rebuild
-                  let build_result =
-                    shellout.command(["build"], run: "gleam", in: ".", opt: [])
-
-                  case build_result {
-                    Ok(_output) -> {
-                      let mods = modified_modules()
-                      list.each(mods, purge)
-                      let _ = atomic_load(mods)
-                      builder.callback(state, path)
+                  case builder.before_callback {
+                    Some(before) -> {
+                      // If we have a before callback, we can run it before
+                      // executing the reload.
+                      before(state, path)
+                      execute_reload(builder, state, path)
                     }
-
-                    Error(#(_status, message)) -> {
-                      message
-                      |> io.print_error
-
-                      state
+                    _ -> {
+                      execute_reload(builder, state, path)
                     }
                   }
                 }
+
                 _ -> state
               }
             }
@@ -156,7 +259,3 @@ pub fn start_state(
   })
   |> filespy.start()
 }
-// todo:
-// - make it so only one callback can be set (maybe one per directory?)
-// - default state is nil, default callback is printing reloaded
-// - callback returns actor stuff


### PR DESCRIPTION
added before_ready callback capabilities. before_ready can store a long running workflow that needs to run before the final build and reload!