### PR TITLE
Update to recent OTP versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.0.0"
+          gleam-version: "1.12.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam format --check src test

--- a/dev/message.gleam
+++ b/dev/message.gleam
@@ -1,0 +1,3 @@
+pub fn get_message() -> String {
+  "Hello!"
+}

--- a/dev/radiate_dev.gleam
+++ b/dev/radiate_dev.gleam
@@ -1,0 +1,24 @@
+import gleam/erlang/process
+import gleam/io
+import message
+import radiate
+
+pub fn main() {
+  let _ =
+    radiate.new()
+    |> radiate.add_dir(".")
+    |> radiate.start()
+
+  let timer_subject = process.new_subject()
+
+  print_every_second(timer_subject)
+}
+
+fn print_every_second(subject: process.Subject(Nil)) {
+  process.send_after(subject, 1000, Nil)
+
+  let _ = process.receive(subject, 1500)
+  io.println(message.get_message())
+
+  print_every_second(subject)
+}

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,7 +6,7 @@ version = "1.0.0"
 #
 description = "Hot reloading while in development for Gleam"
 licences = ["Apache-2.0"]
-repository = {type = "github", user = "h22roscoe", repo = "gleam-radiate"}
+repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,10 +10,11 @@ repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-filespy = ">= 0.4.0 and < 1.0.0"
-gleam_otp = "~> 0.10"
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-shellout = "~> 1.5"
+filespy = { git = "https://github.com/h22roscoe/gleam-filespy.git", ref = "76a1562bbd950728bae4258ad3a19072158b8291" }
+gleam_erlang = ">= 1.2.0 and < 2.0.0"
+gleam_otp = ">= 1.0.0 and < 2.0.0"
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+shellout = ">= 1.7.0 and < 2.0.0"
 
 [dev-dependencies]
-gleeunit = "~> 1.0"
+gleeunit = ">= 1.6.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-filespy = { git = "https://github.com/h22roscoe/gleam-filespy.git", ref = "76a1562bbd950728bae4258ad3a19072158b8291" }
+filespy = ">= 1.0.0 and < 2.0.0"
 gleam_erlang = ">= 1.2.0 and < 2.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-filespy = ">= 1.0.0 and < 2.0.0"
+filespy = ">= 0.7.0 and < 0.8.0"
 gleam_erlang = ">= 1.2.0 and < 2.0.0"
 gleam_otp = ">= 1.0.0 and < 2.0.0"
 gleam_stdlib = ">= 0.44.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,12 +1,12 @@
 name = "radiate"
-version = "0.4.0"
+version = "1.0.0"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.
 #
 description = "Hot reloading while in development for Gleam"
 licences = ["Apache-2.0"]
-repository = {type = "github", user = "pta2002", repo = "gleam-radiate"}
+repository = {type = "github", user = "h22roscoe", repo = "gleam-radiate"}
 # links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,18 +2,19 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filespy", version = "0.4.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "filespy", source = "hex", outer_checksum = "950469A2FA50265EB84530637D3E9597C2CA676A2EEABC98C69A83C77316709C" },
-  { name = "fs", version = "8.6.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "61EA2BDAEDAE4E2024D0D25C63E44DCCF65622D4402DB4A2DF12868D1546503F" },
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "shellout", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "E2FCD18957F0E9F67E1F497FC9FF57393392F8A9BAEAEA4779541DE7A68DD7E0" },
+  { name = "filespy", version = "1.0.0", build_tools = ["gleam"], requirements = ["fs", "gleam_erlang", "gleam_otp", "gleam_stdlib"], source = "git", repo = "https://github.com/h22roscoe/gleam-filespy.git", commit = "76a1562bbd950728bae4258ad3a19072158b8291" },
+  { name = "fs", version = "11.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "fs", source = "hex", outer_checksum = "DD00A61D89EAC01D16D3FC51D5B0EB5F0722EF8E3C1A3A547CD086957F3260A9" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_otp", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "7987CBEBC8060B88F14575DEF546253F3116EBE2A5DA6FD82F38243FCE97C54B" },
+  { name = "gleam_stdlib", version = "0.62.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0080706D3A5A9A36C40C68481D1D231D243AF602E6D2A2BE67BA8F8F4DFF45EC" },
+  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
+  { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
 ]
 
 [requirements]
-filespy = { version = ">= 0.4.0 and < 1.0.0"}
-gleam_otp = { version = "~> 0.10" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
-gleeunit = { version = "~> 1.0" }
-shellout = { version = "~> 1.5" }
+filespy = { git = "https://github.com/h22roscoe/gleam-filespy.git", ref = "76a1562bbd950728bae4258ad3a19072158b8291" }
+gleam_erlang = { version = ">= 1.2.0 and < 2.0.0" }
+gleam_otp = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
+gleeunit = { version = ">= 1.6.0 and < 2.0.0" }
+shellout = { version = ">= 1.7.0 and < 2.0.0" }

--- a/src/radiate.gleam
+++ b/src/radiate.gleam
@@ -95,7 +95,6 @@ pub fn add_dir(
   has_callback,
   has_before_callback,
 ) {
-  echo dir
   Builder(
     dirs: [dir, ..builder.dirs],
     callback: builder.callback,


### PR DESCRIPTION
This addresses issue #9. This should work once the filespy dependency PR goes in because that also has a dep on older versions addressed [here](https://github.com/pta2002/gleam-filespy/pull/10)